### PR TITLE
Remove unused main_driver argument

### DIFF
--- a/main.py
+++ b/main.py
@@ -541,7 +541,7 @@ def save_to_csv(data, file_path):
             writer.writerow(company)
 
 
-def process_company_batch(companies_basic_data, main_driver):
+def process_company_batch(companies_basic_data):
     try:
         driver = setup_driver()
         companies_data = []
@@ -685,7 +685,7 @@ def main():
             
             futures = []
             for batch in batches:
-                future = executor.submit(process_company_batch, batch, driver)
+                future = executor.submit(process_company_batch, batch)
                 futures.append(future)
             
             all_companies_data = []


### PR DESCRIPTION
## Summary
- drop unused main_driver argument from process_company_batch
- update thread submission to pass only batch

## Testing
- `python -m py_compile main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894e43e63a083268c8ec1a3da81a75b